### PR TITLE
Change search button type to "submit"

### DIFF
--- a/components/search.js
+++ b/components/search.js
@@ -24,7 +24,7 @@ function Search(props) {
         />
         <button
           className="flex-shrink-0 bg-blue-500 hover:bg-blue-700 border-blue-500 hover:border-blue-700 text-sm border-4 text-white py-1 px-2 rounded"
-          type="button"
+          type="submit"
         >
           Buscar
         </button>


### PR DESCRIPTION
Form submission function was not being executed when clicking search.

By setting button type to `submit` this no longer happens :)

Awesome work, btw! That was fast!